### PR TITLE
Changed integer to int to sync with base type

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -557,7 +557,7 @@ class AlterQuery(DDLQuery):
                 print_warn(f'schema validation using {tok}')
 
             elif tok.match(tokens.Name.Builtin, (
-                'integer', 'bool', 'char', 'date', 'boolean',
+                'int', 'bool', 'char', 'date', 'boolean',
                 'datetime', 'float', 'time', 'number', 'string'
             )):
                 print_warn('column type validation')


### PR DESCRIPTION
## Context
Unable to run migration script due to Database Error exception
```python
migrations.AddField(
            model_name='taskresult',
            name='assigner',
            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='task_assigner', to=settings.AUTH_USER_MODEL),
        ),
```
## Detail Error
labeling-api-server               | Operations to perform:
labeling-api-server               |   Apply all migrations: admin, auth, contenttypes, guardian, labeling, sessions
labeling-api-server               | Running migrations:
labeling-api-server               |   Applying labeling.0002_auto_20201005_1114...This version of djongo does not support "schema validation using NOT NULL" fully. Visit https://www.patreon.com/nesdis
labeling-api-server               | This version of djongo does not support "COLUMN DROP DEFAULT " fully. Visit https://www.patreon.com/nesdis
labeling-api-server               | Not implemented alter command for SQL ALTER TABLE "labeling_taskresult" ADD COLUMN "assigner_id" int NULL
mongodb                           | 2020-10-05T04:14:44.232+0000 I NETWORK  [conn7] end connection 172.21.0.11:48212 (4 connections now open)
mongodb                           | 2020-10-05T04:14:44.232+0000 I NETWORK  [conn8] end connection 172.21.0.11:48214 (3 connections now open)
labeling-api-server               | Traceback (most recent call last):
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 842, in parse
labeling-api-server               |     return handler(self, statement)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 868, in _alter
labeling-api-server               |     query = AlterQuery(self.db, self.connection_properties, sm, self._params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 424, in __init__
labeling-api-server               |     super().__init__(*args)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 83, in __init__
labeling-api-server               |     super().__init__(*args)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 61, in __init__
labeling-api-server               |     self.parse()
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 434, in parse
labeling-api-server               |     self._add(statement)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 594, in _add
labeling-api-server               |     raise SQLDecodeError
labeling-api-server               | djongo.exceptions.SQLDecodeError
labeling-api-server               | 
labeling-api-server               | The above exception was the direct cause of the following exception:
labeling-api-server               | 
labeling-api-server               | Traceback (most recent call last):
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/cursor.py", line 56, in execute
labeling-api-server               |     params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 769, in __init__
labeling-api-server               |     self._query = self.parse()
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/sql2mongo/query.py", line 864, in parse
labeling-api-server               |     raise exe from e
labeling-api-server               | djongo.exceptions.SQLDecodeError: FAILED SQL: ALTER TABLE "labeling_taskresult" ADD COLUMN "assigner_id" int NULL
labeling-api-server               | Params: []
labeling-api-server               | Version: 1.3.2
labeling-api-server               | 
labeling-api-server               | The above exception was the direct cause of the following exception:
labeling-api-server               | 
labeling-api-server               | Traceback (most recent call last):
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
labeling-api-server               |     return self.cursor.execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/cursor.py", line 59, in execute
labeling-api-server               |     raise db_exe from e
labeling-api-server               | djongo.database.DatabaseError
labeling-api-server               | 
labeling-api-server               | The above exception was the direct cause of the following exception:
labeling-api-server               | 
labeling-api-server               | Traceback (most recent call last):
labeling-api-server               |   File "manage.py", line 21, in <module>
labeling-api-server               |     main()
labeling-api-server               |   File "manage.py", line 17, in main
labeling-api-server               |     execute_from_command_line(sys.argv)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
labeling-api-server               |     utility.execute()
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
labeling-api-server               |     self.fetch_command(subcommand).run_from_argv(self.argv)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
labeling-api-server               |     self.execute(*args, **cmd_options)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
labeling-api-server               |     output = self.handle(*args, **options)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 83, in wrapped
labeling-api-server               |     res = handle_func(*args, **kwargs)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 234, in handle
labeling-api-server               |     fake_initial=fake_initial,
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 117, in migrate
labeling-api-server               |     state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
labeling-api-server               |     state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/migrations/executor.py", line 245, in apply_migration
labeling-api-server               |     state = migration.apply(state, schema_editor)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/migrations/migration.py", line 124, in apply
labeling-api-server               |     operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/migrations/operations/fields.py", line 112, in database_forwards
labeling-api-server               |     field,
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/base/schema.py", line 447, in add_field
labeling-api-server               |     self.execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/base/schema.py", line 137, in execute
labeling-api-server               |     cursor.execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 99, in execute
labeling-api-server               |     return super().execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 67, in execute
labeling-api-server               |     return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
labeling-api-server               |     return executor(sql, params, many, context)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
labeling-api-server               |     return self.cursor.execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/utils.py", line 89, in __exit__
labeling-api-server               |     raise dj_exc_value.with_traceback(traceback) from exc_value
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
labeling-api-server               |     return self.cursor.execute(sql, params)
labeling-api-server               |   File "/usr/local/lib/python3.6/site-packages/djongo/cursor.py", line 59, in execute
labeling-api-server               |     raise db_exe from e
labeling-api-server               | django.db.utils.DatabaseError

## Reason
There are unexpected query format (I think come from the migration sql) which caused djongo unable to parse it from SQL style to mongo query
